### PR TITLE
Bug fix for "heroku accounts" after fresh install

### DIFF
--- a/lib/ext/heroku/command/accounts.rb
+++ b/lib/ext/heroku/command/accounts.rb
@@ -12,7 +12,7 @@ class Heroku::Command::Accounts < Heroku::Command::Base
   def index
     display "No accounts found." if account_names.empty?
 
-    current_account = Heroku::Auth.extract_account
+    current_account = Heroku::Auth.extract_account rescue nil
 
     account_names.each do |name|
       if name == current_account


### PR DESCRIPTION
"heroku accounts" assumes that an account is currently selected, either using the "--account" option, an environment variable, or a git config option. For new users who have just installed, that won't be the case.

There is no reason why "heroku accounts" should crash if no account is selected -- this little patch ensures that it doesn't.
