### PR TITLE
Fix for problem with spaces in public key file path on Windows

### DIFF
--- a/lib/ext/heroku/command/accounts.rb
+++ b/lib/ext/heroku/command/accounts.rb
@@ -51,7 +51,7 @@ class Heroku::Command::Accounts < Heroku::Command::Base
         file.puts
         file.puts "Host heroku.#{name}"
         file.puts "  HostName heroku.com"
-        file.puts "  IdentityFile #{account_ssh_key(name)}"
+        file.puts "  IdentityFile \"#{account_ssh_key(name)}\""
         file.puts "  IdentitiesOnly yes"
       end
 


### PR DESCRIPTION
Fixes #17

Some months ago, I had problems with `heroku accounts:add --auto`. Eventually I discovered that editing `.ssh/config` and putting quotes around the path to the public key file resolved the problem. (The path had embedded spaces, and it seems that SSH couldn't parse it correctly.)

I never contributed a patch for this at the time, but today I was doing something with `heroku-accounts` and it came back to me.

I don't know what the effect of quoting the paths in `.ssh/config` would be on Linux and other non-Windows platforms, and I don't have machines available which I can test on. I also don't know whether a different version of OpenSSH might be able to correctly parse paths with embedded spaces, without quoting.
