### PR TITLE
quote ssh-keygen filename

### DIFF
--- a/lib/accounts/heroku/command/accounts.rb
+++ b/lib/accounts/heroku/command/accounts.rb
@@ -49,7 +49,7 @@ class Heroku::Command::Accounts < Heroku::Command::Base
 
     if options[:auto] then
       display "Generating new SSH key"
-      system %{ ssh-keygen -t rsa -f #{account_ssh_key(name)} -N "" }
+      system %{ ssh-keygen -t rsa -f "#{account_ssh_key(name)}" -N "" }
 
       display "Adding entry to ~/.ssh/config"
       File.open(File.expand_path("~/.ssh/config"), "a") do |file|


### PR DESCRIPTION
Windows home directories basically always have spaces in them. So we should make sure we're expecting that. I put quotes around the filename in the `ssh-keygen` command, because without them a Windows client was unable to automatically generate an ssh key.

If you don't need to support Ruby 1.8.7, Ruby's `.shellescape` would be a more robust solution.
