### PR TITLE
Make this plugin stop issuing fatal git warnings in non-git directories

### DIFF
--- a/lib/accounts/heroku/command/base.rb
+++ b/lib/accounts/heroku/command/base.rb
@@ -5,6 +5,8 @@ class Heroku::Command::Base
   def git_remotes(base_dir)
     remotes = {}
 
+    return unless File.exists?(".git")
+    
     FileUtils.chdir(base_dir) do
       remote_names = %x{ git remote }.split("\n").map { |r| r.strip }
       remote_names.each do |name|


### PR DESCRIPTION
If you use this plugin in a non-git directory, you get the following error message:

```
plugins ➤ heroku version                                                                                                                                                
fatal: Not a git repository (or any of the parent directories): .git
heroku-toolbelt/2.33.3 (universal-darwin12.0) ruby/1.8.7
```

This is because the plugin overrides git_remotes but doesn't carry out a check for the existences of a .git directory which the overridden method does.
