### PR TITLE
#issue58: unset the default account in the local config during remove.

### DIFF
--- a/lib/accounts/heroku/command/accounts.rb
+++ b/lib/accounts/heroku/command/accounts.rb
@@ -92,6 +92,9 @@ class Heroku::Command::Accounts < Heroku::Command::Base
     if %x{ git config --global heroku.account }.chomp == name
       %x{ git config --global --unset heroku.account }
     end
+    if %x{ git config heroku.account }.chomp == name
+      %x{ git config --unset heroku.account }
+    end
 
     display "Account removed: #{name}"
   end


### PR DESCRIPTION
If the local configuration uses the removed account as the default one, unset it.
