### PR TITLE
Reduce permissions

### DIFF
--- a/lib/accounts/heroku/command/accounts.rb
+++ b/lib/accounts/heroku/command/accounts.rb
@@ -177,7 +177,7 @@ private ######################################################################
   end
 
   def write_account(name, account)
-    File.open(account_file(name), "w") { |f| f.puts YAML::dump(account) }
+    File.open(account_file(name), "w", 0600) { |f| f.puts YAML::dump(account) }
   end
 
   def error(message)


### PR DESCRIPTION
I just noticed that the ~/.heroku/accounts directory is visible to other users of my machine making my credentials readable to anyone. While the set of users using my machine only includes me, I thought it would be nice to restrict it.
