### PR TITLE
Prevent removing the current account.

### DIFF
--- a/lib/accounts/heroku/command/accounts.rb
+++ b/lib/accounts/heroku/command/accounts.rb
@@ -85,6 +85,7 @@ class Heroku::Command::Accounts < Heroku::Command::Base
 
     error("Please specify an account name.") unless name
     error("That account does not exist.") unless account_exists?(name)
+    error("That account is the current account, set another account first.") if (current_account = Heroku::Auth.extract_account rescue nil) == name
 
     FileUtils.rm_f(account_file(name))
 


### PR DESCRIPTION
It's easy to get heroku-accounts into a state where it can't do anything, and the only way to fix it is to know to edit .git/config and change or remove the [heroku] section.

This change prevents removing the current account, which prevents that scenario.

There may well be a much better way to do this, it's my first ruby code.
