### PR TITLE
Set base_dir to Dir.pwd for compatibility

### DIFF
--- a/lib/accounts/heroku/command/base.rb
+++ b/lib/accounts/heroku/command/base.rb
@@ -2,7 +2,7 @@ require "heroku/command/base"
 
 class Heroku::Command::Base
 
-  def git_remotes(base_dir)
+  def git_remotes(base_dir=Dir.pwd)
     remotes = {}
 
     return unless File.exists?(".git")


### PR DESCRIPTION
I couldn't install `heroku-deploy-rails` because `git_remotes` was expecting an argument. This argument is optional in the heroku api and defaults to `Dir.pwd`.
