### PR TITLE
Add a note about Heroku's official fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+### NOTE: Consider Using Heroku's Official Fork:
+
+Heroku has created an official fork of this repo. It supports http-git which is now the Heroku default:
+
+https://github.com/heroku/heroku-accounts
+
 # Heroku Accounts
 
 Helps use multiple accounts on Heroku.


### PR DESCRIPTION
I think it'd be beneficial to point users to Heroku's official fork.
